### PR TITLE
WIP: core/IFuseFeeDistributor interface is currently incomplete

### DIFF
--- a/src/core/IFuseFeeDistributor.sol
+++ b/src/core/IFuseFeeDistributor.sol
@@ -2,66 +2,162 @@ pragma solidity 0.5.17;
 pragma experimental ABIEncoderV2;
 
 interface IFuseFeeDistributor {
-    function minBorrowEth() external view returns (uint256);
+    event OwnershipTransferred(
+        address indexed previousOwner,
+        address indexed newOwner
+    );
 
-    function maxSupplyEth() external view returns (uint256);
+    function _callPool(address[] memory targets, bytes[] memory data) external;
 
-    function maxUtilizationRate() external view returns (uint256);
+    function _callPool(address[] memory targets, bytes memory data) external;
 
-    function interestFeeRate() external view returns (uint256);
+    function _editCErc20DelegateWhitelist(
+        address[] memory oldImplementations,
+        address[] memory newImplementations,
+        bool[] memory allowResign,
+        bool[] memory statuses
+    ) external;
 
-    function _callPool(address[] calldata targets, bytes[] calldata data)
+    function _editCEtherDelegateWhitelist(
+        address[] memory oldImplementations,
+        address[] memory newImplementations,
+        bool[] memory allowResign,
+        bool[] memory statuses
+    ) external;
+
+    function _editComptrollerImplementationWhitelist(
+        address[] memory oldImplementations,
+        address[] memory newImplementations,
+        bool[] memory statuses
+    ) external;
+
+    function _editGuardianWhitelist(
+        address[] memory accounts,
+        bool[] memory status
+    ) external;
+
+    function _latestCErc20Delegate(address)
+        external
+        view
+        returns (
+            address implementation,
+            bool allowResign,
+            bytes memory becomeImplementationData
+        );
+
+    function _latestCEtherDelegate(address)
+        external
+        view
+        returns (
+            address implementation,
+            bool allowResign,
+            bytes memory becomeImplementationData
+        );
+
+    function _pauseAllBorrowing() external;
+
+    function _setCustomInterestFeeRate(address comptroller, int256 rate)
         external;
 
-    function owner() external view returns (address);
+    function _setDefaultInterestFeeRate(uint256 _defaultInterestFeeRate)
+        external;
 
-    function comptrollerImplementationWhitelist(
-        address oldImplementation,
-        address newImplementation
-    ) external view returns (bool);
-
-    function cErc20DelegateWhitelist(
+    function _setLatestCErc20Delegate(
         address oldImplementation,
         address newImplementation,
-        bool allowResign
+        bool allowResign,
+        bytes memory becomeImplementationData
+    ) external;
+
+    function _setLatestCEtherDelegate(
+        address oldImplementation,
+        address newImplementation,
+        bool allowResign,
+        bytes memory becomeImplementationData
+    ) external;
+
+    function _setLatestComptrollerImplementation(
+        address oldImplementation,
+        address newImplementation
+    ) external;
+
+    function _setPoolLimits(
+        uint256 _minBorrowEth,
+        uint256 _maxSupplyEth,
+        uint256 _maxUtilizationRate
+    ) external;
+
+    function _withdrawAssets(address erc20Contract) external;
+
+    function cErc20DelegateWhitelist(
+        address,
+        address,
+        bool
     ) external view returns (bool);
 
     function cEtherDelegateWhitelist(
-        address oldImplementation,
-        address newImplementation,
-        bool allowResign
+        address,
+        address,
+        bool
     ) external view returns (bool);
 
-    function latestComptrollerImplementation(address oldImplementation)
+    function comptrollerImplementationWhitelist(address, address)
         external
         view
+        returns (bool);
+
+    function customInterestFeeRates(address) external view returns (int256);
+
+    function defaultInterestFeeRate() external view returns (uint256);
+
+    function deployCErc20(bytes memory constructorData)
+        external
         returns (address);
+
+    function deployCEther(bytes memory constructorData)
+        external
+        returns (address);
+
+    function initialize(uint256 _defaultInterestFeeRate) external;
+
+    function interestFeeRate() external view returns (uint256);
+
+    function isGuardian(address) external view returns (bool);
 
     function latestCErc20Delegate(address oldImplementation)
         external
         view
         returns (
-            address cErc20Delegate,
-            bool allowResign,
-            bytes memory becomeImplementationData
+            address,
+            bool,
+            bytes memory
         );
 
     function latestCEtherDelegate(address oldImplementation)
         external
         view
         returns (
-            address cEtherDelegate,
-            bool allowResign,
-            bytes memory becomeImplementationData
+            address,
+            bool,
+            bytes memory
         );
 
-    function deployCEther(bytes calldata constructorData)
+    function latestComptrollerImplementation(address oldImplementation)
         external
+        view
         returns (address);
 
-    function deployCErc20(bytes calldata constructorData)
-        external
-        returns (address);
+    function maxSupplyEth() external view returns (uint256);
+
+    function maxUtilizationRate() external view returns (uint256);
+
+    function minBorrowEth() external view returns (uint256);
+
+    function owner() external view returns (address);
+
+    function renounceOwnership() external;
+
+    function transferOwnership(address newOwner) external;
 
     function() external payable;
 }

--- a/src/core/IFuseFeeDistributor.sol
+++ b/src/core/IFuseFeeDistributor.sol
@@ -7,33 +7,35 @@ interface IFuseFeeDistributor {
         address indexed newOwner
     );
 
-    function _callPool(address[] memory targets, bytes[] memory data) external;
+    function _callPool(address[] calldata targets, bytes[] calldata data)
+        external;
 
-    function _callPool(address[] memory targets, bytes memory data) external;
+    function _callPool(address[] calldata targets, bytes calldata data)
+        external;
 
     function _editCErc20DelegateWhitelist(
-        address[] memory oldImplementations,
-        address[] memory newImplementations,
-        bool[] memory allowResign,
-        bool[] memory statuses
+        address[] calldata oldImplementations,
+        address[] calldata newImplementations,
+        bool[] calldata allowResign,
+        bool[] calldata statuses
     ) external;
 
     function _editCEtherDelegateWhitelist(
-        address[] memory oldImplementations,
-        address[] memory newImplementations,
-        bool[] memory allowResign,
-        bool[] memory statuses
+        address[] calldata oldImplementations,
+        address[] calldata newImplementations,
+        bool[] calldata allowResign,
+        bool[] calldata statuses
     ) external;
 
     function _editComptrollerImplementationWhitelist(
-        address[] memory oldImplementations,
-        address[] memory newImplementations,
-        bool[] memory statuses
+        address[] calldata oldImplementations,
+        address[] calldata newImplementations,
+        bool[] calldata statuses
     ) external;
 
     function _editGuardianWhitelist(
-        address[] memory accounts,
-        bool[] memory status
+        address[] calldata accounts,
+        bool[] calldata status
     ) external;
 
     function _latestCErc20Delegate(address)
@@ -66,14 +68,14 @@ interface IFuseFeeDistributor {
         address oldImplementation,
         address newImplementation,
         bool allowResign,
-        bytes memory becomeImplementationData
+        bytes calldata becomeImplementationData
     ) external;
 
     function _setLatestCEtherDelegate(
         address oldImplementation,
         address newImplementation,
         bool allowResign,
-        bytes memory becomeImplementationData
+        bytes calldata becomeImplementationData
     ) external;
 
     function _setLatestComptrollerImplementation(
@@ -110,11 +112,11 @@ interface IFuseFeeDistributor {
 
     function defaultInterestFeeRate() external view returns (uint256);
 
-    function deployCErc20(bytes memory constructorData)
+    function deployCErc20(bytes calldata constructorData)
         external
         returns (address);
 
-    function deployCEther(bytes memory constructorData)
+    function deployCEther(bytes calldata constructorData)
         external
         returns (address);
 


### PR DESCRIPTION
Minor issue but it fixes the incompleteness of the interface.

Closes: #9 

Updates `core/IFuseFeeDistributor` interface as it is currently incomplete.

The interface generator automatically uses `memory` instead of `calldata` upon constructing the interface which is incorrect.
Perhaps there is a way of adding that information to the generated ABI so that the interfaces can be reconstructed correctly.